### PR TITLE
find opt in llvm

### DIFF
--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -12,6 +12,7 @@
 # LLVM_LIBRARIES             - A list of libraries which should be linked
 # LLVM_DYNAMIC_LIBRARY       - A single dynamic llvm shared library
 # LLVM_DYNAMIC_LIBRARY_FOUND - Whether found the dynamic llvm shared library
+# LLVM_OPT                   - opt program in llvm
 # 
 # Using Following macros to set library:
 # llvm_map_components_to_libraries(OUTPUT_VARIABLE ${llvm components})
@@ -49,6 +50,7 @@ if(NOT(DEFINED LLVM_ROOT) )
 	endif()
 	# find llvm-config. perfers to the one with version suffix, Ex:llvm-config-3.2
 	find_program(LLVM_CONFIG_EXE NAMES "llvm-config-${LLVM_RECOMMAND_VERSION}" "llvm-config")
+   find_program(LLVM_OPT NAMES "opt-${LLVM_RECOMMAND_VERSION}" "opt")
 
 	if(NOT LLVM_CONFIG_EXE)
 		set(LLVM_FOUND False)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ set(SELF ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_command(OUTPUT inst-timing
    COMMAND clang -O0 -DTIMING_${TIMING} ${SELF}/inst-timing.c -emit-llvm -c -o inst-timing.bc
-   COMMAND opt -load ${PROJECT_BINARY_DIR}/lib/libLLVMProfiling.so -InstTemplate inst-timing.bc -o inst-timing2.bc
+   COMMAND ${LLVM_OPT} -load ${PROJECT_BINARY_DIR}/lib/libLLVMProfiling.so -InstTemplate inst-timing.bc -o inst-timing2.bc
    COMMAND clang -O0 inst-timing2.bc -o inst-timing -lm
    DEPENDS ${SELF}/inst-timing.c ${SELF}/libtiming.c ${SELF}/../lib/InstTemplate.cpp
    )


### PR DESCRIPTION
增加了alloca,getelementptr,Conversion,icmp,fcmp,select等指令，并修改为InstTemplate，移植到llvm-prof中
格式：
load : 1.411500 cycles
store : 1.008000 cycles
sub : 0.988500 cycles
fsub : 3.993500 cycles
mul : 2.989000 cycles
fmul : 5.460500 cycles
add : 0.957500 cycles
fadd : 3.970000 cycles
urem : 19.693000 cycles
srem : 24.788500 cycles
frem : 34.326000 cycles
udiv : 18.691500 cycles
sdiv : 25.787000 cycles
fdiv : 21.374000 cycles
ashr : 0.968000 cycles
lshr : 0.966500 cycles
shl : 0.978000 cycles
xor : 0.981000 cycles
or : 0.979500 cycles
and : 0.976500 cycles
alloca : 6.842000 cycles
getelementptr : 1.353500 cycles
trunc_to : 3.828500 cycles
zext_to : 3.267000 cycles
sext_to : 3.645500 cycles
fptrunc_to : 8.773500 cycles
fpext_to : 8.772500 cycles
fptoui_to : 6.555500 cycles
fptosi_to : 6.602500 cycles
uitofp_to : 1.108000 cycles
sitofp_to : 6.547500 cycles
ptrtoint_to : 0.758000 cycles
inttoptr_to : 3.272000 cycles
bitcast_to : 1.140000 cycles
icmp : 6.571000 cycles
fcmp : 6.314000 cycles
select : 12.012000 cycles